### PR TITLE
fixed an issue in the README: sensu client was given a user instead of t...

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Pysensu uses the hostname and port where your sensu-api is running.
 
     from pysensu import pysensu
 
-    client = pysensu.Pysensu("sensu.organization.com", 4567)
+    client = pysensu.Pysensu("sensu.organization.com", port=4567)
 
     # Stashes
     client.create_stash('server1')


### PR DESCRIPTION
...he port number

the second positional argument to Pysensu.**init**() is user, not port
